### PR TITLE
Add interactive simulation

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The code currently provides:
 - `Voxel` – a container for particles within a single cell
 - `SparseGrid` – a hash‑map based sparse voxel grid
 
-`main.rs` shows a tiny demonstration inserting particles into the grid.
+`main.rs` now provides a simple interactive simulation you can run with `cargo run`. The grid is printed as ASCII art and you can step the simulation or add new particles at runtime.
 
 ## Why Sparse Voxels?
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,20 +1,50 @@
 mod sim;
 
-use sim::{vec3::Vec3, particle::Particle, sparse_grid::SparseGrid};
+use std::io::{self, Write};
+
+use sim::{vec3::Vec3, particle::Particle, simulation::Simulation};
 
 const MAX_PARTICLES_PER_VOXEL: usize = 32;
 
 fn main() {
-    let mut grid: SparseGrid<MAX_PARTICLES_PER_VOXEL> = SparseGrid::new();
+    let mut sim: Simulation<MAX_PARTICLES_PER_VOXEL> =
+        Simulation::new(0.1, Vec3::new(0.0, -9.81, 0.0));
 
-    for i in 0..100 {
-        let p = Particle::new(
-            Vec3::new(i as f32 * 0.1, 0.0, 0.0),
-            Vec3::zero(),
-            1.0,
-        );
-        grid.insert(p);
+    // initial particle
+    sim.add_particle(Particle::new(Vec3::new(0.0, 4.0, 0.0), Vec3::zero(), 1.0));
+
+    println!("Simple MPM simulation. Commands: step [n], add x y, quit");
+    loop {
+        sim.display(-10..=10, -5..=5, 0);
+        print!("command> ");
+        io::stdout().flush().unwrap();
+        let mut input = String::new();
+        if io::stdin().read_line(&mut input).is_err() {
+            break;
+        }
+        let mut parts = input.split_whitespace();
+        match parts.next() {
+            Some("step") => {
+                let n: u32 = parts.next().unwrap_or("1").parse().unwrap_or(1);
+                for _ in 0..n {
+                    sim.step();
+                }
+            }
+            Some("add") => {
+                if let (Some(x), Some(y)) = (parts.next(), parts.next()) {
+                    if let (Ok(xv), Ok(yv)) = (x.parse::<f32>(), y.parse::<f32>()) {
+                        sim.add_particle(Particle::new(
+                            Vec3::new(xv, yv, 0.0),
+                            Vec3::zero(),
+                            1.0,
+                        ));
+                    }
+                }
+            }
+            Some("quit") | Some("exit") => break,
+            _ => {
+                println!("commands: step [n], add x y, quit");
+            }
+        }
     }
-
-    println!("Inserted {} voxels", grid.voxel_count());
 }

--- a/src/sim/mod.rs
+++ b/src/sim/mod.rs
@@ -3,3 +3,4 @@ pub mod particle;
 pub mod fixed_vec;
 pub mod voxel;
 pub mod sparse_grid;
+pub mod simulation;

--- a/src/sim/simulation.rs
+++ b/src/sim/simulation.rs
@@ -1,0 +1,67 @@
+use super::{particle::Particle, sparse_grid::SparseGrid, vec3::Vec3, voxel::Voxel};
+
+pub struct Simulation<const N: usize> {
+    pub grid: SparseGrid<N>,
+    gravity: Vec3,
+    dt: f32,
+}
+
+impl<const N: usize> Simulation<N> {
+    pub fn new(dt: f32, gravity: Vec3) -> Self {
+        Self { grid: SparseGrid::new(), gravity, dt }
+    }
+
+    pub fn add_particle(&mut self, particle: Particle) {
+        self.grid.insert(particle);
+    }
+
+    pub fn step(&mut self) {
+        let mut moves: Vec<((i32, i32, i32), usize, (i32, i32, i32), Particle)> = Vec::new();
+        for (key, voxel) in self.grid.iter_mut() {
+            let len = voxel.particles.len();
+            for i in 0..len {
+                if let Some(p) = voxel.particles.get_mut(i) {
+                    p.velocity += self.gravity * self.dt;
+                    p.position += p.velocity * self.dt;
+                    let new_key = (
+                        p.position.x().floor() as i32,
+                        p.position.y().floor() as i32,
+                        p.position.z().floor() as i32,
+                    );
+                    if new_key != *key {
+                        moves.push((*key, i, new_key, *p));
+                    }
+                }
+            }
+        }
+        for (old_key, idx, new_key, particle) in moves.into_iter().rev() {
+            if let Some(voxel) = self.grid.voxel_mut(old_key) {
+                voxel.remove(idx);
+                if voxel.is_empty() {
+                    self.grid.remove_voxel(old_key);
+                }
+            }
+            let voxel = self.grid.voxels.entry(new_key).or_insert_with(Voxel::new);
+            let _ = voxel.particles.push(particle);
+        }
+    }
+
+    pub fn display(&self, x_range: std::ops::RangeInclusive<i32>, y_range: std::ops::RangeInclusive<i32>, z: i32) {
+        for y in y_range.clone().rev() {
+            for x in x_range.clone() {
+                let key = (x, y, z);
+                if let Some(voxel) = self.grid.voxel(key) {
+                    let count = voxel.particles.len();
+                    if count > 0 {
+                        print!("{}", count.min(9));
+                    } else {
+                        print!(".");
+                    }
+                } else {
+                    print!(".");
+                }
+            }
+            println!();
+        }
+    }
+}

--- a/src/sim/sparse_grid.rs
+++ b/src/sim/sparse_grid.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use super::{particle::Particle, voxel::Voxel};
 
 pub struct SparseGrid<const N: usize> {
-    voxels: HashMap<(i32, i32, i32), Voxel<N>>,
+    pub(crate) voxels: HashMap<(i32, i32, i32), Voxel<N>>,
 }
 
 impl<const N: usize> SparseGrid<N> {
@@ -25,7 +25,23 @@ impl<const N: usize> SparseGrid<N> {
         self.voxels.get(&key)
     }
 
+    pub fn voxel_mut(&mut self, key: (i32, i32, i32)) -> Option<&mut Voxel<N>> {
+        self.voxels.get_mut(&key)
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = (&(i32, i32, i32), &Voxel<N>)> {
+        self.voxels.iter()
+    }
+
+    pub fn iter_mut(&mut self) -> impl Iterator<Item = (&(i32, i32, i32), &mut Voxel<N>)> {
+        self.voxels.iter_mut()
+    }
+
     pub fn voxel_count(&self) -> usize {
         self.voxels.len()
+    }
+
+    pub fn remove_voxel(&mut self, key: (i32, i32, i32)) {
+        self.voxels.remove(&key);
     }
 }

--- a/src/sim/voxel.rs
+++ b/src/sim/voxel.rs
@@ -12,5 +12,13 @@ impl<const N: usize> Voxel<N> {
     pub fn is_full(&self) -> bool {
         self.particles.len() >= self.particles.capacity()
     }
+
+    pub fn is_empty(&self) -> bool {
+        self.particles.len() == 0
+    }
+
+    pub fn remove(&mut self, idx: usize) -> Option<Particle> {
+        self.particles.swap_remove(idx)
+    }
 }
 


### PR DESCRIPTION
## Summary
- implement a basic `Simulation` struct with step and display logic
- expose mutable iteration for voxels
- provide CLI in `main.rs` for stepping and adding particles
- document interactive usage in README

## Testing
- `cargo check`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_685e17aaf43483248dfba74cf401b2b7